### PR TITLE
Fixes #520

### DIFF
--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -64,13 +64,20 @@ export class Others {
 
   async ActiveSet(value: CharacteristicValue): Promise<void> {
     this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} On: ${value}`);
-    this.Active = value;
-    this.accessory.context.Active = this.Active;
     if (value) {
       await this.pushOnChanges();
     } else {
       await this.pushOffChanges();
     }
+    
+    /*
+    pushOnChanges and pushOffChanges above assume they are measuring the state of the accessory BEFORE
+    they are updated, so we are only updating the accessory state after calling the above.
+    */
+    
+    this.Active = value;
+    this.accessory.context.Active = this.Active;
+
   }
 
   /**


### PR DESCRIPTION
pushOnChanges and pushOffChanges in other.ts assume they are measuring the state of the accessory BEFORE they are updated, so we are now only updating the accessory state _after_ calling the above.

This fixes a bug which caused API calls to never run, because some booleans were guaranteed to be false.